### PR TITLE
Add initial Dragon Ball API with character endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # DBAPI
-A full-featured Dragon Ball API
+
+DBAPI is a simple REST API that serves real Dragon Ball data for use in applications, games and prototypes.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn dbapi.main:app --reload
+```
+
+## Endpoints
+
+- `GET /characters` – List all characters.
+- `GET /characters/{id}` – Retrieve a character by its numeric ID.
+
+## Testing
+
+```bash
+pytest
+```

--- a/dbapi/data/characters.json
+++ b/dbapi/data/characters.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": 1,
+    "name": "Goku",
+    "race": "Saiyan",
+    "description": "The main protagonist of Dragon Ball, raised on Earth and protector of the universe.",
+    "ki": 9001,
+    "originPlanet": "Planet Vegeta"
+  },
+  {
+    "id": 2,
+    "name": "Vegeta",
+    "race": "Saiyan",
+    "description": "Prince of the fallen Saiyan race and rival to Goku.",
+    "ki": 18000,
+    "originPlanet": "Planet Vegeta"
+  },
+  {
+    "id": 3,
+    "name": "Piccolo",
+    "race": "Namekian",
+    "description": "A wise and powerful warrior from Planet Namek.",
+    "ki": 3500,
+    "originPlanet": "Planet Namek"
+  },
+  {
+    "id": 4,
+    "name": "Bulma",
+    "race": "Human",
+    "description": "A brilliant scientist and founding member of the Dragon Team.",
+    "ki": 5,
+    "originPlanet": "Earth"
+  }
+]

--- a/dbapi/main.py
+++ b/dbapi/main.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import json
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="DBAPI", description="Dragon Ball API", version="0.1.0")
+
+DATA_FILE = Path(__file__).parent / "data" / "characters.json"
+
+class Character(BaseModel):
+    id: int
+    name: str
+    race: str
+    description: str
+    ki: int
+    originPlanet: str
+
+with open(DATA_FILE) as f:
+    _characters: List[Character] = [Character(**c) for c in json.load(f)]
+
+@app.get("/characters", response_model=List[Character])
+def list_characters() -> List[Character]:
+    return _characters
+
+@app.get("/characters/{character_id}", response_model=Character)
+def get_character(character_id: int) -> Character:
+    for character in _characters:
+        if character.id == character_id:
+            return character
+    raise HTTPException(status_code=404, detail="Character not found")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pydantic==2.5.3
+httpx==0.27.0
+pytest==8.1.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+# Ensure project root is on sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from dbapi.main import app
+
+client = TestClient(app)
+
+
+def test_get_characters():
+    response = client.get("/characters")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert any(char["name"] == "Goku" for char in data)
+
+
+def test_get_character_by_id():
+    response = client.get("/characters/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Goku"
+
+
+def test_get_character_not_found():
+    response = client.get("/characters/999")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- implement FastAPI service exposing Dragon Ball character data
- add sample dataset and tests
- document setup and usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898baa588908326bb51078c330eb607