### PR TITLE
Add character filtering and document port usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ DBAPI is a simple REST API that serves real Dragon Ball data for use in applicat
 
 ```bash
 pip install -r requirements.txt
-uvicorn dbapi.main:app --reload
+# By default the API runs on port 8000. Use --port to specify another port
+# if 8000 is already in use, e.g. 8080.
+uvicorn dbapi.main:app --reload --port 8080
 ```
 
 ## Endpoints
 
-- `GET /characters` – List all characters.
+- `GET /characters` – List all characters. Optional query parameters
+  `race` and `name` can be used to filter the results.
 - `GET /characters/{id}` – Retrieve a character by its numeric ID.
 
 ## Testing

--- a/dbapi/main.py
+++ b/dbapi/main.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import json
 from typing import List, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
 
 app = FastAPI(title="DBAPI", description="Dragon Ball API", version="0.1.0")
@@ -21,8 +21,17 @@ with open(DATA_FILE) as f:
     _characters: List[Character] = [Character(**c) for c in json.load(f)]
 
 @app.get("/characters", response_model=List[Character])
-def list_characters() -> List[Character]:
-    return _characters
+def list_characters(
+    race: Optional[str] = Query(None, description="Filter by race"),
+    name: Optional[str] = Query(None, description="Filter by name substring"),
+) -> List[Character]:
+    """Return characters optionally filtered by race or name."""
+    results = _characters
+    if race:
+        results = [c for c in results if c.race.lower() == race.lower()]
+    if name:
+        results = [c for c in results if name.lower() in c.name.lower()]
+    return results
 
 @app.get("/characters/{character_id}", response_model=Character)
 def get_character(character_id: int) -> Character:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,6 +19,21 @@ def test_get_characters():
     assert any(char["name"] == "Goku" for char in data)
 
 
+def test_filter_characters_by_race():
+    response = client.get("/characters", params={"race": "Saiyan"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert all(char["race"] == "Saiyan" for char in data)
+
+
+def test_filter_characters_by_name():
+    response = client.get("/characters", params={"name": "go"})
+    assert response.status_code == 200
+    data = response.json()
+    assert any("go" in char["name"].lower() for char in data)
+
+
 def test_get_character_by_id():
     response = client.get("/characters/1")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Document how to specify a custom port when starting the API
- Allow filtering characters by race or name substring
- Test new filtering capabilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898bf7e60b48326b0a33a49ba4592e3