### PR TITLE
Expand Dragon Ball API with planets and sagas

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ uvicorn dbapi.main:app --reload --port 8080
 ## Endpoints
 
 - `GET /characters` – List all characters. Optional query parameters
-  `race` and `name` can be used to filter the results.
+  `race`, `name`, `originPlanet` and `min_ki` can be used to filter the results.
 - `GET /characters/{id}` – Retrieve a character by its numeric ID.
+- `GET /planets` – List all known planets. Optional `name` query parameter.
+- `GET /planets/{id}` – Retrieve a planet by its numeric ID.
+- `GET /sagas` – List major story sagas. Optional `name` query parameter.
+- `GET /sagas/{id}` – Retrieve a saga by its numeric ID.
 
 ## Testing
 

--- a/dbapi/data/planets.json
+++ b/dbapi/data/planets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "name": "Earth",
+    "description": "Home of the Dragon Team and site of many battles.",
+    "galaxy": "Milky Way"
+  },
+  {
+    "id": 2,
+    "name": "Planet Vegeta",
+    "description": "Homeworld of the Saiyan race until its destruction.",
+    "galaxy": "Milky Way"
+  },
+  {
+    "id": 3,
+    "name": "Planet Namek",
+    "description": "Home planet of the Namekians and source of the Namekian Dragon Balls.",
+    "galaxy": "Namekian Galaxy"
+  }
+]

--- a/dbapi/data/sagas.json
+++ b/dbapi/data/sagas.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 1,
+    "name": "Saiyan Saga",
+    "description": "The arrival of the Saiyan warriors on Earth."
+  },
+  {
+    "id": 2,
+    "name": "Frieza Saga",
+    "description": "The battle against Frieza on Planet Namek."
+  },
+  {
+    "id": 3,
+    "name": "Cell Saga",
+    "description": "The conflict involving the Androids and Cell."
+  }
+]

--- a/dbapi/main.py
+++ b/dbapi/main.py
@@ -5,9 +5,12 @@ from typing import List, Optional
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel
 
-app = FastAPI(title="DBAPI", description="Dragon Ball API", version="0.1.0")
+app = FastAPI(title="DBAPI", description="Dragon Ball API", version="0.2.0")
 
-DATA_FILE = Path(__file__).parent / "data" / "characters.json"
+CHARACTERS_FILE = Path(__file__).parent / "data" / "characters.json"
+PLANETS_FILE = Path(__file__).parent / "data" / "planets.json"
+SAGAS_FILE = Path(__file__).parent / "data" / "sagas.json"
+
 
 class Character(BaseModel):
     id: int
@@ -17,21 +20,49 @@ class Character(BaseModel):
     ki: int
     originPlanet: str
 
-with open(DATA_FILE) as f:
+
+class Planet(BaseModel):
+    id: int
+    name: str
+    description: str
+    galaxy: str
+
+
+class Saga(BaseModel):
+    id: int
+    name: str
+    description: str
+
+
+with open(CHARACTERS_FILE) as f:
     _characters: List[Character] = [Character(**c) for c in json.load(f)]
+
+with open(PLANETS_FILE) as f:
+    _planets: List[Planet] = [Planet(**p) for p in json.load(f)]
+
+with open(SAGAS_FILE) as f:
+    _sagas: List[Saga] = [Saga(**s) for s in json.load(f)]
+
 
 @app.get("/characters", response_model=List[Character])
 def list_characters(
     race: Optional[str] = Query(None, description="Filter by race"),
     name: Optional[str] = Query(None, description="Filter by name substring"),
+    originPlanet: Optional[str] = Query(None, description="Filter by origin planet"),
+    min_ki: Optional[int] = Query(None, description="Filter by minimum ki level"),
 ) -> List[Character]:
-    """Return characters optionally filtered by race or name."""
+    """Return characters optionally filtered by race, name, origin planet or ki."""
     results = _characters
     if race:
         results = [c for c in results if c.race.lower() == race.lower()]
     if name:
         results = [c for c in results if name.lower() in c.name.lower()]
+    if originPlanet:
+        results = [c for c in results if c.originPlanet.lower() == originPlanet.lower()]
+    if min_ki is not None:
+        results = [c for c in results if c.ki >= min_ki]
     return results
+
 
 @app.get("/characters/{character_id}", response_model=Character)
 def get_character(character_id: int) -> Character:
@@ -39,4 +70,38 @@ def get_character(character_id: int) -> Character:
         if character.id == character_id:
             return character
     raise HTTPException(status_code=404, detail="Character not found")
+
+
+@app.get("/planets", response_model=List[Planet])
+def list_planets(name: Optional[str] = Query(None, description="Filter by name substring")) -> List[Planet]:
+    """Return planets optionally filtered by name."""
+    results = _planets
+    if name:
+        results = [p for p in results if name.lower() in p.name.lower()]
+    return results
+
+
+@app.get("/planets/{planet_id}", response_model=Planet)
+def get_planet(planet_id: int) -> Planet:
+    for planet in _planets:
+        if planet.id == planet_id:
+            return planet
+    raise HTTPException(status_code=404, detail="Planet not found")
+
+
+@app.get("/sagas", response_model=List[Saga])
+def list_sagas(name: Optional[str] = Query(None, description="Filter by name substring")) -> List[Saga]:
+    """Return sagas optionally filtered by name."""
+    results = _sagas
+    if name:
+        results = [s for s in results if name.lower() in s.name.lower()]
+    return results
+
+
+@app.get("/sagas/{saga_id}", response_model=Saga)
+def get_saga(saga_id: int) -> Saga:
+    for saga in _sagas:
+        if saga.id == saga_id:
+            return saga
+    raise HTTPException(status_code=404, detail="Saga not found")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,21 @@ def test_filter_characters_by_name():
     assert any("go" in char["name"].lower() for char in data)
 
 
+def test_filter_characters_by_origin_planet():
+    response = client.get("/characters", params={"originPlanet": "Planet Vegeta"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert all(char["originPlanet"] == "Planet Vegeta" for char in data)
+
+
+def test_filter_characters_by_min_ki():
+    response = client.get("/characters", params={"min_ki": 10000})
+    assert response.status_code == 200
+    data = response.json()
+    assert all(char["ki"] >= 10000 for char in data)
+
+
 def test_get_character_by_id():
     response = client.get("/characters/1")
     assert response.status_code == 200
@@ -43,4 +58,42 @@ def test_get_character_by_id():
 
 def test_get_character_not_found():
     response = client.get("/characters/999")
+    assert response.status_code == 404
+
+
+def test_get_planets():
+    response = client.get("/planets")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(planet["name"] == "Earth" for planet in data)
+
+
+def test_get_planet_by_id():
+    response = client.get("/planets/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Earth"
+
+
+def test_get_planet_not_found():
+    response = client.get("/planets/999")
+    assert response.status_code == 404
+
+
+def test_get_sagas():
+    response = client.get("/sagas")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(saga["name"] == "Saiyan Saga" for saga in data)
+
+
+def test_get_saga_by_id():
+    response = client.get("/sagas/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Saiyan Saga"
+
+
+def test_get_saga_not_found():
+    response = client.get("/sagas/999")
     assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add planets and sagas datasets
- expose new `/planets` and `/sagas` endpoints with filtering
- allow character filtering by origin planet and minimum ki

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c5b687c88326b44cec55d67353e3